### PR TITLE
improvements to initial waiting for tee times to load

### DIFF
--- a/booking_tool.py
+++ b/booking_tool.py
@@ -11,12 +11,6 @@ import logging
 
 
 def book(args):
-    logging.basicConfig(
-        filename="teetimes.txt",
-        format="%(asctime)s :: %(levelname)s :: %(message)s",
-        encoding="utf-8",
-        level=logging.INFO,
-    )
     booked = False
     try_num = 0
     max_tries = 10
@@ -72,28 +66,12 @@ def book(args):
                 driver.get(new_url)
 
                 try:
-                    # First check to see if there are no tee times
-                    no_tee_times = None
-                    try:
-                        no_tee_times = WebDriverWait(driver, 5).until(
-                            EC.presence_of_element_located(
-                                (By.XPATH, "//*[@data-testid='no-tee-times-found']")
-                            )
-                        )
-                    except Exception as e:
-                        logging.error(e.args)
-                        logging.error("assuming we found some tee times")
-                    if no_tee_times:
+                    found_tee_times = handlers.check_for_tee_times(driver=driver)
+                    if found_tee_times:
+                        logging.info("found tee times")
+                    else:
                         logging.warning(f"No tee times found for loop {try_num}")
                         continue
-
-                    # Wait for tee times to load
-                    WebDriverWait(driver, 30).until(
-                        EC.presence_of_element_located(
-                            (By.XPATH, "//*[@data-testid='teetimes-header-date']")
-                        )
-                    )
-                    logging.info("found tee times")
 
                     # Book earliest
                     handlers.book_earliest_date(driver=driver)

--- a/handlers.py
+++ b/handlers.py
@@ -1,4 +1,6 @@
+import logging
 from time import sleep
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -21,6 +23,26 @@ def construct_url(base_url, **params):
         [f"{param}={value}" for param, value in params.items() if value]
     )
     return new_url
+
+
+def check_for_tee_times(driver):
+    # wait until tee times are loaded or no tee times element is found
+    WebDriverWait(driver, 30).until(
+        EC.presence_of_element_located(
+            (
+                By.XPATH,
+                "//*[@data-testid='no-tee-times-found']|//*[@data-testid='teetimes_book_now_button']",
+            )
+        )
+    )
+    try:
+        return (
+            driver.find_element_by_xpath("//*[@data-testid='no-tee-times-found']")
+            == None
+        )
+    except NoSuchElementException as e:
+        logging.warning("going ahead, assuming we found some tee times")
+    return True
 
 
 def book_earliest_date(driver):

--- a/tee_time.py
+++ b/tee_time.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import parser_utils
 from booking_tool import book
 
@@ -58,5 +59,12 @@ parser.add_argument(
 )
 
 args = parser.parse_args()
+
+logging.basicConfig(
+    filename="teetimes.txt",
+    format="%(asctime)s :: %(levelname)s :: %(message)s",
+    encoding="utf-8",
+    level=logging.INFO,
+)
 
 book(vars(args))


### PR DESCRIPTION
```
  WebDriverWait(driver, 30).until(
      EC.presence_of_element_located(
          (
              By.XPATH,
              "//*[@data-testid='no-tee-times-found']|//*[@data-testid='teetimes_book_now_button']",
          )
      )
  )
```
Basically this will wait until either the no-tee-times-found element shows up, or a book_now_button shows up. Once either one is found, we can then determine if tee times exist or not
```
  try:
      return (
          driver.find_element_by_xpath("//*[@data-testid='no-tee-times-found']")
          == None
      )
  except NoSuchElementException as e:
      logging.warning("going ahead, assuming we found some tee times")
  return True
```